### PR TITLE
Remove redundant error return

### DIFF
--- a/npp/nppi/support_functions.go
+++ b/npp/nppi/support_functions.go
@@ -9,183 +9,183 @@ import "unsafe"
 // Memory Management
 
 // Npp8u  * nppiMalloc_8u_C1(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_8u_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_8u_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_8u_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_8u_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp8u  * nppiMalloc_8u_C2(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_8u_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_8u_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_8u_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_8u_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp8u  * nppiMalloc_8u_C3(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_8u_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_8u_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_8u_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_8u_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp8u  * nppiMalloc_8u_C4(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_8u_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_8u_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_8u_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_8u_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16u * nppiMalloc_16u_C1(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16u_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16u_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16u_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16u_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16u * nppiMalloc_16u_C2(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16u_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16u_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16u_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16u_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16u * nppiMalloc_16u_C3(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16u_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16u_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16u_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16u_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16u * nppiMalloc_16u_C4(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16u_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16u_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16u_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16u_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16s * nppiMalloc_16s_C1(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16s_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16s_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16s_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16s_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16s * nppiMalloc_16s_C2(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16s_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16s_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16s_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16s_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16s * nppiMalloc_16s_C4(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16s_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16s_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16s_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16s_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16sc * nppiMalloc_16sc_C1(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16sc_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16sc_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16sc_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16sc_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16sc * nppiMalloc_16sc_C2(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16sc_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16sc_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16sc_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16sc_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16sc * nppiMalloc_16sc_C3(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16sc_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16sc_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16sc_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16sc_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp16sc * nppiMalloc_16sc_C4(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_16sc_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_16sc_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_16sc_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_16sc_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32s * nppiMalloc_32s_C1(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32s_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32s_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32s_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32s_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32s * nppiMalloc_32s_C3(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32s_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32s_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32s_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32s_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32s * nppiMalloc_32s_C4(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32s_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32s_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32s_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32s_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32s * nppiMalloc_32sc_C1(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32sc_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32sc_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32sc_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32sc_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32s * nppiMalloc_32sc_C2(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32sc_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32sc_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32sc_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32sc_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32s * nppiMalloc_32sc_C3(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32sc_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32sc_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32sc_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32sc_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32s * nppiMalloc_32sc_C4(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32sc_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32sc_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32sc_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32sc_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32f * nppiMalloc_32f_C1(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32f_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32f_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32f_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32f_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32f * nppiMalloc_32f_C2(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32f_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32f_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32f_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32f_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32f * nppiMalloc_32f_C3(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32f_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32f_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32f_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32f_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32f * nppiMalloc_32f_C4(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32f_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32f_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32f_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32f_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32fc * nppiMalloc_32fc_C1(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32fc_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32fc_C1(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32fc_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32fc_C1(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32fc * nppiMalloc_32fc_C2(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32fc_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32fc_C2(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32fc_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32fc_C2(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32fc * nppiMalloc_32fc_C3(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32fc_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32fc_C3(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32fc_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32fc_C3(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // Npp32fc * nppiMalloc_32fc_C4(int nWidthPixels, int nHeightPixels, int * pStepBytes);
-func Malloc_32fc_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int, error) {
+func Malloc_32fc_C4(nWidthPixels int, nHeightPixels int) (unsafe.Pointer, int) {
 	var pStepBytes C.int
-	return unsafe.Pointer(C.nppiMalloc_32fc_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes), nil
+	return unsafe.Pointer(C.nppiMalloc_32fc_C4(C.int(nWidthPixels), C.int(nHeightPixels), &pStepBytes)), int(pStepBytes)
 }
 
 // void nppiFree(void * pData);


### PR DESCRIPTION
Users of API should check if the returned device pointer is nil and if the returned step is 0 by themselves, as intended by the design of the C API.